### PR TITLE
Allow POSTting to a controller action that takes a strongly typed model.

### DIFF
--- a/DataTables.Queryable.Samples/Controllers/DataTablesController.cs
+++ b/DataTables.Queryable.Samples/Controllers/DataTablesController.cs
@@ -80,7 +80,7 @@ namespace DataTables.Queryable.Samples.Controllers
             using (var ctx = new DatabaseContext())
             {
                 var persons = ctx.Persons.Include("Office.Address").ToPagedList(request);
-                return JsonDataTable(persons, Convert.ToInt32(Request.QueryString["draw"]));
+                return JsonDataTable(persons, dataTable.draw);
             }
         }
 

--- a/DataTables.Queryable.Samples/Controllers/DataTablesController.cs
+++ b/DataTables.Queryable.Samples/Controllers/DataTablesController.cs
@@ -15,11 +15,14 @@ namespace DataTables.Queryable.Samples.Controllers
         /// </summary>
         public JsonResult Sample1()
         {
+            // https://datatables.net/manual/server-side search "draw"
+            int draw = Convert.ToInt32(Request.QueryString["draw"]);
+
             var request = new DataTablesRequest<Person>(Request.QueryString);
             using (var ctx = new DatabaseContext())
             {
                 var persons = ctx.Persons.Include("Office.Address").ToPagedList(request);
-                return JsonDataTable(persons);
+                return JsonDataTable(persons, draw);
             }
         }
 
@@ -42,7 +45,7 @@ namespace DataTables.Queryable.Samples.Controllers
             using (var ctx = new DatabaseContext())
             {
                 var persons = ctx.Persons.Include("Office").ToPagedList(request);
-                return JsonDataTable(persons);
+                return JsonDataTable(persons, Convert.ToInt32(Request.QueryString["draw"]));
             }
         }
 
@@ -66,7 +69,18 @@ namespace DataTables.Queryable.Samples.Controllers
             using (var ctx = new DatabaseContext())
             {
                 var persons = ctx.Persons.Include("Office").ToPagedList(request);
-                return JsonDataTable(persons);
+                return JsonDataTable(persons, Convert.ToInt32(Request.QueryString["draw"]));
+            }
+        }
+
+        [HttpPost]
+        public JsonResult Sample4(DataTablesAjaxPostModel dataTable)
+        {
+            var request = new DataTablesRequest<Person>(dataTable);
+            using (var ctx = new DatabaseContext())
+            {
+                var persons = ctx.Persons.Include("Office.Address").ToPagedList(request);
+                return JsonDataTable(persons, Convert.ToInt32(Request.QueryString["draw"]));
             }
         }
 
@@ -75,12 +89,13 @@ namespace DataTables.Queryable.Samples.Controllers
         /// </summary>
         /// <param name="model"><see cref="IPagedList{T}"/> collection of items</param>
         /// <returns>JsonNetResult instance to be sent to datatables</returns>
-        protected JsonNetResult JsonDataTable<T>(IPagedList<T> model)
+        protected JsonNetResult JsonDataTable<T>(IPagedList<T> model, int draw)
         {
             JsonNetResult jsonResult = new JsonNetResult();
             jsonResult.JsonRequestBehavior = JsonRequestBehavior.AllowGet;
             jsonResult.Data = new
             {
+                draw = draw,
                 recordsTotal = model.TotalCount,
                 recordsFiltered = model.TotalCount,
                 data = model

--- a/DataTables.Queryable.Samples/Controllers/WebUIController.cs
+++ b/DataTables.Queryable.Samples/Controllers/WebUIController.cs
@@ -18,5 +18,10 @@ namespace DataTables.Queryable.Samples.Controllers
         {
             return View();
         }
+
+        public ActionResult Sample4()
+        {
+            return View();
+        }
     }
 }

--- a/DataTables.Queryable.Samples/DataTables.Queryable.Samples.csproj
+++ b/DataTables.Queryable.Samples/DataTables.Queryable.Samples.csproj
@@ -27,6 +27,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>12.0</OldToolsVersion>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -466,6 +467,7 @@
   <ItemGroup>
     <Content Include="Views\web.config" />
     <Content Include="Views\_Layout.cshtml" />
+    <Content Include="Views\Sample4.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -495,7 +497,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
+          <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>52698</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/DataTables.Queryable.Samples/Views/Sample4.cshtml
+++ b/DataTables.Queryable.Samples/Views/Sample4.cshtml
@@ -1,6 +1,6 @@
 ﻿@{
     Layout = "_Layout.cshtml";
-    ViewBag.Title = "Sample 1: Basic usage";
+    ViewBag.Title = "Sample 1: ajax POST";
 }
 
 <h3>@ViewBag.Title</h3>
@@ -53,13 +53,14 @@
 <code class="csharp">
 // DataTablesController.cs:
 
-public JsonResult Sample1()
+[HttpPost]
+public JsonResult Sample4(DataTablesAjaxPostModel dataTable)
 {
-    var request = new DataTablesRequest&lt;Person&gt;(Request.QueryString);
+var request = new DataTablesRequest<Person>(dataTable);
     using (var ctx = new DatabaseContext())
     {
         var persons = ctx.Persons.Include("Office.Address").ToPagedList(request);
-        return JsonDataTable(persons);
+        return JsonDataTable(persons, dataTable.draw);
     }
 }
 </code>

--- a/DataTables.Queryable.Samples/Views/Sample4.cshtml
+++ b/DataTables.Queryable.Samples/Views/Sample4.cshtml
@@ -1,0 +1,121 @@
+﻿@{
+    Layout = "_Layout.cshtml";
+    ViewBag.Title = "Sample 1: Basic usage";
+}
+
+<h3>@ViewBag.Title</h3>
+<p>This page demonstrates basic usage of <samp>DataTables.Queryable</samp> library with all features enabled using an ajax POST:</p>
+<ul>
+    <li>Global search by all columns with default predicate <code>String.Contains(...)</code></li>
+    <li>Individual column search with default predicate <code>String.Contains(...)</code></li>
+    <li>Binding to and search/order by nested properties (<samp>Office</samp>, <samp>Address</samp>)</li>
+    <li>Sorting by all column with multisort support</li>
+    <li>Pagination</li>
+    <li>ajax POST</li>
+</ul>
+<p>Tips:</p>
+<ul>
+    <li>Check the Visual Studio output view (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>) to see how the datatables-to-server request is translated to LINQ and Entity Framework query.</li>
+    <li>Try multi-column ordering with pressed <kbd>Shift</kbd> and click on a column.</li>
+</ul>   
+<br />
+
+<table id="table" class="table table-condensed table-bordered table-vcentered dataTable">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Position</th>
+            <th>Office</th>
+            <th>Address</th>
+            <th>Extn.</th>
+            <th>Start date</th>
+            <th>Salary</th>
+        </tr>
+    </thead>
+    <tfoot>
+        <tr>
+            <th>Name</th>
+            <th>Position</th>
+            <th>Office</th>
+            <th>Address</th>
+            <th>Extn.</th>
+            <th>Start date</th>
+            <th>Salary</th>
+        </tr>
+    </tfoot>
+</table>
+
+<br />
+
+<p>Server-side code:</p>
+
+<pre>
+<code class="csharp">
+// DataTablesController.cs:
+
+public JsonResult Sample1()
+{
+    var request = new DataTablesRequest&lt;Person&gt;(Request.QueryString);
+    using (var ctx = new DatabaseContext())
+    {
+        var persons = ctx.Persons.Include("Office.Address").ToPagedList(request);
+        return JsonDataTable(persons);
+    }
+}
+</code>
+</pre>
+
+<script type="text/javascript">
+    $(function () {
+
+        $('#table tfoot th').each(function () {
+            var title = $(this).text();
+            $(this).html('<input type="text" class="form-control" style="width: 100%" placeholder="Search ' + title + '" />');
+        });
+
+        var table = $('#table').DataTable({
+            autoWidth: false,
+            processing: true,
+            serverSide: true,
+            order: [[0, "asc"]],
+            pageLength: 10,
+            ajax: {
+                url: '/DataTables/Sample4',
+                type: 'POST'
+            },
+            columnDefs: [
+                { targets: 0, data: 'Name' },
+                { targets: 1, data: 'Position' },
+                { targets: 2, data: 'Office.Name' },
+                {
+                    targets: 3, data: 'Office.Address.Street',
+                    render: function (street, type, person, meta) { return person.Office.Address.Street + ", " + person.Office.Address.Building; }
+                },
+                { targets: 4, data: 'Extn' },
+                {
+                    targets: 5, data: 'StartDate',
+                    render: function (data) { return Date.parse(data).toString('MMMM dd, yyyy'); }
+                },
+                {
+                    targets: 6, data: 'Salary'
+                },
+            ]
+        });
+
+        // Apply the search
+        table.columns().every(function () {
+            var that = this;
+
+            $('input', this.footer()).on('keyup change', function () {
+                if (that.search() !== this.value) {
+                    that
+                        .search(this.value)
+                        .draw();
+                }
+            });
+        });
+
+        hljs.initHighlightingOnLoad();
+    });
+</script>
+

--- a/DataTables.Queryable.Samples/Views/_Layout.cshtml
+++ b/DataTables.Queryable.Samples/Views/_Layout.cshtml
@@ -29,16 +29,17 @@
     </div>
 
     <div class="container body-content">
-        <br />        
+        <br />
         <a href="~/Sample1">Basic usage</a> |
         <a href="~/Sample2">Custom search predicate</a> |
-        <a href="~/Sample3">Custom filter with parameters</a>
+        <a href="~/Sample3">Custom filter with parameters</a> |
+        <a href="~/Sample4">Ajax POST</a>
         <hr />
 
         @RenderBody()
         <hr />
         <footer>
-            <p>&copy; Alexander Krutov, 2016</p>           
+            <p>&copy; Alexander Krutov, 2016</p>
         </footer>
     </div>
 </body>

--- a/DataTables.Queryable/DataTables.Queryable.csproj
+++ b/DataTables.Queryable/DataTables.Queryable.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataTablesAjaxPostModel.cs" />
     <Compile Include="DataTablesColumn.cs" />
     <Compile Include="DataTablesQueryable.cs" />
     <Compile Include="DataTablesQueryProvider.cs" />

--- a/DataTables.Queryable/DatatablesAjaxPostModel.cs
+++ b/DataTables.Queryable/DatatablesAjaxPostModel.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace DataTables.Queryable
+{
+    public class DataTablesAjaxPostModel
+    {
+        public int draw { get; set; }
+        public int start { get; set; }
+        public int length { get; set; }
+        public List<Column> columns { get; set; }
+        public Search search { get; set; }
+        public List<Order> order { get; set; }
+    }
+
+    public class Column
+    {
+        public string data { get; set; }
+        public string name { get; set; }
+        public bool searchable { get; set; }
+        public bool orderable { get; set; }
+        public Search search { get; set; }
+    }
+
+    public class Search
+    {
+        public string value { get; set; }
+        public bool regex { get; set; }
+        public bool cisearch { get; set; }
+        public bool ciorder { get; set; }
+    }
+
+    public class Order
+    {
+        public int column { get; set; }
+        public string dir { get; set; }
+    }
+}


### PR DESCRIPTION
Big benefits here are being able to self-document the needed parameters through Swagger/Swashbuckle.

The initial processing of the request is also greatly simplified.

ref https://github.com/AlexanderKrutov/DataTables.Queryable/issues/16