### PR TITLE
Add null checks around `Columns[i].Search`

### DIFF
--- a/DataTables.Queryable/DataTablesAjaxPostModel.cs
+++ b/DataTables.Queryable/DataTablesAjaxPostModel.cs
@@ -139,8 +139,8 @@ namespace DataTables.Queryable
                 model[$"columns[{i}][name]"] = Columns[i].Name;
                 model[$"columns[{i}][searchable]"] = Columns[i].Searchable.ToString();
                 model[$"columns[{i}][orderable]"] = Columns[i].Searchable.ToString();
-                model[$"columns[{i}][search][value]"] = Columns[i].Search.Value;
-                model[$"columns[{i}][search][regex]"] = Columns[i].Search.Regex.ToString();
+                model[$"columns[{i}][search][value]"] = Columns[i].Search?.Value;
+                model[$"columns[{i}][search][regex]"] = Columns[i].Search?.Regex.ToString();
             }
 
             for (int i = 0; i < Order.Count; i++)


### PR DESCRIPTION
Ref https://github.com/AlexanderKrutov/DataTables.Queryable/issues/31